### PR TITLE
add geocoding start & end location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,12 @@ gem 'redis', '~> 4.0'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'devise'
+
+# Image Hosting
 gem 'cloudinary'
+
+# Geocoding
+gem 'geocoder'
 
 # Strava Login
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     ffi (1.13.1)
     font-awesome-sass (5.15.1)
       sassc (>= 1.11)
+    geocoder (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (4.1.0)
@@ -293,6 +294,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   font-awesome-sass
+  geocoder
   jbuilder (~> 2.7)
   listen (~> 3.2)
   omniauth

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -1,4 +1,19 @@
 class Route < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
+
+  validates :start_location, presence: true
+  validates :end_location, presence: true
+
+  before_save :lookup_locations
+
+  private
+
+  def lookup_locations
+    self.start_latitude = Geocoder.search(start_location)[0].data['lat']
+    self.start_longitude = Geocoder.search(start_location)[0].data['lon']
+    self.end_latitude = Geocoder.search(end_location)[0].data['lat']
+    self.end_longitude = Geocoder.search(end_location)[0].data['lon']
+    binding.pry
+  end
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,22 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+  # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  units: :km,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+)


### PR DESCRIPTION
There is now way in the gem two geocode 2 different field for the same model.

Doing manually with the before_save. To make sure this does not fail the `validate` on those 2 fields is required 👍 